### PR TITLE
Update Chitchatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Chitchatter is a free (as in both price and freedom) communication tool. It is d
 
 * Official app website: <https://chitchatter.im/>
 * Upstream app code repository: <https://github.com/jeremyckahn/chitchatter>
-* YunoHost documentation for this app: <https://yunohost.org/app_chitchatter>
+* YunoHost Store: <https://apps.yunohost.org/app/chitchatter>
 * Report a bug: <https://github.com/YunoHost-Apps/chitchatter_ynh/issues>
 
 ## Developer info

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Chitchatter is a free (as in both price and freedom) communication tool. It is d
 - Ephemeral
 - Decentralized 
 
-**Shipped version:** 1.0~ynh9
+**Shipped version:** 1.0~ynh10
 
 **Demo:** https://chitchatter.im/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -27,7 +27,7 @@ Chitchatter est un outil de communication gratuit (comme dans le prix et la libe
 - Éphémère
 - Décentralisé
 
-**Version incluse :** 1.0~ynh9
+**Version incluse :** 1.0~ynh10
 
 **Démo :** https://chitchatter.im/
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -39,7 +39,7 @@ Chitchatter est un outil de communication gratuit (comme dans le prix et la libe
 
 * Site officiel de l’app : <https://chitchatter.im/>
 * Dépôt de code officiel de l’app : <https://github.com/jeremyckahn/chitchatter>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_chitchatter>
+* YunoHost Store: <https://apps.yunohost.org/app/chitchatter>
 * Signaler un bug : <https://github.com/YunoHost-Apps/chitchatter_ynh/issues>
 
 ## Informations pour les développeurs

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Chitchatter"
 description.en = "Peer-to-peer chat that is serverless, decentralized, and ephemeral"
 description.fr = "Chat peer-to-peer sans serveur, décentralisée et éphémère"
 
-version = "1.0~ynh9"
+version = "1.0~ynh10"
 
 maintainers = ["eric_G"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,7 +8,7 @@
 
 # nodejs version
 nodejs_version=18
-version_commit=3fe80f58fd7aa55dd299af2864060445e963e415
+version_commit=d546fef71ce95b561017bad466ee0294987a5383
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
Bump commit hash to [d546fef71ce95b561017bad466ee0294987a5383](https://github.com/jeremyckahn/chitchatter/commit/d546fef71ce95b561017bad466ee0294987a5383)

Fixes #14 