### PR TITLE
Update _common.sh to fix YNH 12 Install

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,7 +8,7 @@
 
 # nodejs version
 nodejs_version=20
-version_commit=fcf9fcea52d1e09d689ed6998d729aa8d08be604
+version_commit=0bf0bf327bbcffe577fb5ec6f4e3d98d1ab711f8
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem

- Yunohost 12 experienced an error with the rollup dependency on install of the chitchatter app. Would fix #24 

## Solution

- Changed the commit id the install pointed to with the [most recent commit](https://github.com/jeremyckahn/chitchatter/commit/0bf0bf327bbcffe577fb5ec6f4e3d98d1ab711f8) on the main branch of chitchatter

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
